### PR TITLE
i18n/ internationalization support

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -2,7 +2,7 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value =~ /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i
-      record.errors[attribute] << (options[:message] || "is not valid")
+      record.errors.add(attribute, options[:message] || "is not valid")
     end
   end
 end


### PR DESCRIPTION
When passing a symbol for the error message i18n gets used to resolve it :)

Fixes https://github.com/balexand/email_validator/issues/2
