### PR TITLE
Regular expression fix

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -9,7 +9,7 @@ class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     options = @@default_options.merge(self.options)
     name_validation = options[:strict_mode] ? "-a-z0-9+._" : "^@\\s"
-    unless value =~ /^\s*([#{name_validation}]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*$/i
+    unless value =~ /\A\s*([#{name_validation}]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i
       record.errors.add(attribute, options[:message] || :invalid)
     end
   end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -84,7 +84,8 @@ describe EmailValidator do
         "invalid-ip@127.0.0.1.26",
         "another-invalid-ip@127.0.0.256",
         "IP-and-port@127.0.0.1:25",
-        "the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.net"
+        "the-local-part-is-invalid-if-it-is-longer-than-sixty-four-characters@sld.net",
+        "user@example.com\n<script>alert('hello')</script>"
       ].each do |email|
 
         it "#{email.inspect} should not be valid" do


### PR DESCRIPTION
In Ruby, `^` and `$` match the line beginning and line end. So, Rails will convert an email
coming in via HTTP like this:

```
user@example.com%0A<script>alert('hello')</script>
```

To:

```
user@example.com\n<script>alert('hello')</script>
```

and unintentionally passes validation because the regular expression
matched the email: up to the line end, the rest does not matter.

http://guides.rubyonrails.org/security.html#regular-expressions
