### PR TITLE
make blank emails valid

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -7,6 +7,7 @@ class EmailValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
+    return if value.blank?
     options = @@default_options.merge(self.options)
     name_validation = options[:strict_mode] ? "-a-z0-9+._" : "^@\\s"
     unless value =~ /\A\s*([#{name_validation}]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i


### PR DESCRIPTION
Currently the gem validates blank emails to false which is bad for models where the email attribute is allowed to be blank. The presence validation of this attribute should be part of the model and not part of the gem.
