### PR TITLE
Add a class method for simpler validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ If you need to validate an email outside a model, you can get the regexp :
 ### Normal mode
 
 ```ruby
-EmailValidator.regexp
+EmailValidator.regexp # returns the regex
+EmailValidator.valid?('narf@example.com') # boolean
 ```
 
 ### Strict mode

--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -10,6 +10,10 @@ class EmailValidator < ActiveModel::EachValidator
     /\A\s*([#{name_validation}]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i
   end
 
+  def self.valid?(value, options = {})
+    !!(value =~ regexp(options))
+  end
+
   def self.default_options
     @@default_options
   end
@@ -17,7 +21,7 @@ class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     options = @@default_options.merge(self.options)
 
-    unless value =~ self.class.regexp(options)
+    unless self.class.valid?(value, self.options)
       record.errors.add(attribute, options[:message] || :invalid)
     end
   end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -59,11 +59,15 @@ describe EmailValidator do
         end
 
         it "#{email.inspect} should match the regexp" do
-          (email =~ EmailValidator.regexp).should be_true
+          (!!(email =~ EmailValidator.regexp)).should be_truthy
         end
 
         it "#{email.inspect} should match the strict regexp" do
-          (email =~ EmailValidator.regexp(:strict_mode => true)).should be_true
+          (!!(email =~ EmailValidator.regexp(:strict_mode => true))).should be_truthy
+        end
+
+        it "#{email.inspect} should pass the class tester" do
+          expect(EmailValidator.valid?(email)).to be_truthy
         end
 
       end
@@ -105,11 +109,15 @@ describe EmailValidator do
         end
 
         it "#{email.inspect} should not match the regexp" do
-          (email =~ EmailValidator.regexp).should be_false
+          expect(email =~ EmailValidator.regexp).to be_falsy
         end
 
         it "#{email.inspect} should not match the strict regexp" do
-          (email =~ EmailValidator.regexp(:strict_mode => true)).should be_false
+          expect(email =~ EmailValidator.regexp(:strict_mode => true)).to be_falsy
+        end
+
+        it "#{email.inspect} should fail the class tester" do
+          expect(EmailValidator.valid?(email)).to be_falsy
         end
 
       end
@@ -134,11 +142,11 @@ describe EmailValidator do
         end
 
         it "#{email.inspect} should match the regexp" do
-          (email =~ EmailValidator.regexp).should be_true
+          expect(email =~ EmailValidator.regexp).to be_truthy
         end
 
         it "#{email.inspect} should not match the strict regexp" do
-          (email =~ EmailValidator.regexp(:strict_mode => true)).should be_false
+          expect(email =~ EmailValidator.regexp(:strict_mode => true)).to be_falsy
         end
 
       end


### PR DESCRIPTION
Adds the boolean `EmailValidator.valid?('narf@example.com')`, incorporating the work of @TiteiKo
