### PR TITLE
Do not allow double dots and dots in beginning or end of local part of address

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -5,9 +5,9 @@ class EmailValidator < ActiveModel::EachValidator
   def self.regexp(options = {})
     options = default_options.merge(options)
 
-    name_validation = options[:strict_mode] ? "-a-z0-9+._" : "^@\\s"
+    name_validation = options[:strict_mode] ? "(?!\\.)(?:[-a-z0-9+_]|\\.(?![\\.@]))" : "[^@\\s]"
 
-    /\A\s*([#{name_validation}]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i
+    /\A\s*(#{name_validation}{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i
   end
 
   def self.valid?(value, options = {})

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -129,6 +129,10 @@ describe EmailValidator do
         "hans(peter@example.com",
         "hans)peter@example.com",
         "partially.\"quoted\"@sld.com",
+        ".dot@at.start.of.local.part",
+        "dot.at.@end.of.local.part",
+        "double..dots@in.local.part",
+        ".help..dots.everywhere.@in.local.part",
         "&'*+-./=?^_{}~@other-valid-characters-in-local.net",
         "mixed-1234-in-{+^}-local@sld.net"
       ].each do |email|


### PR DESCRIPTION
Many mail servers do not accept emails to addresses like foo.bar.@gmail.com.
So we should treat them as invalid in strict mode.

See http://www.remote.org/jochen/mail/info/chars.html for details.

Here I'm using a bit of lookahead magick in regular expressions to not match dots in beginning or end of local part of address and also double dots in it.

Closes https://github.com/balexand/email_validator/issues/26
