### PR TITLE
half_width_alphanumeric_mode

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -7,8 +7,9 @@ class EmailValidator < ActiveModel::EachValidator
     options = default_options.merge(options)
 
     name_validation = options[:strict_mode] ? "-\\p{L}\\d+._" : "^@\\s"
+    half_width_alphanumeric = options[:half_width_alphanumeric_mode] ? "\w" : ""
 
-    /\A\s*([#{name_validation}]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
+    /\A\s*([#{half_width_alphanumeric}#{name_validation}]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
   end
 
   def self.valid?(value, options = {})

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -9,6 +9,10 @@ class StrictUser < TestModel
   validates :email, :email => {:strict_mode => true}
 end
 
+class HalfWidthAlphanumeric < TestModel
+  validates :email, :email => {:half_width_alphanumeric_mode => true}
+end
+
 class TestUserAllowsNil < TestModel
   validates :email, :email => {:allow_nil => true}
 end
@@ -149,6 +153,31 @@ describe EmailValidator do
 
         it "#{email.inspect} should not match the strict regexp" do
           expect(email =~ EmailValidator.regexp(:strict_mode => true)).to be_falsy
+        end
+
+      end
+    end
+
+    context "given the emails that should be invalid in half_width_alphanumeric_mode but valid in normal mode" do
+      [
+        "寿司@japan.com",
+        "ящик@яндекс.рф"
+      ].each do |email|
+
+        it "#{email.inspect} should be valid" do
+          expect(TestUser.new(:email => email)).to be_valid
+        end
+
+        it "#{email.inspect} should not be valid in strict_mode" do
+          expect(HalfWidthAlphanumeric.new(:email => email)).not_to be_valid
+        end
+
+        it "#{email.inspect} should match the regexp" do
+          expect(email =~ EmailValidator.regexp).to be_truthy
+        end
+
+        it "#{email.inspect} should not match the strict regexp" do
+          expect(email =~ EmailValidator.regexp(:half_width_alphanumeric_mode => true)).to be_falsy
         end
 
       end


### PR DESCRIPTION
Hi balexand

I live from japan.
I use email_validator in Japanese

e.g

```
寿司@example.com
```

It does not hit the validation in Japanese.

because I am able to pass a single-byte non-alphanumeric characters.

There is half_width_alphanumeric_mode.

So that this mode is not going through the character of non-alphanumeric characters.

plaease think about it.
