### PR TITLE
Add literal apostrophe to the strict mode regexp

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -6,7 +6,7 @@ class EmailValidator < ActiveModel::EachValidator
   def self.regexp(options = {})
     options = default_options.merge(options)
 
-    name_validation = options[:strict_mode] ? "-\\p{L}\\d+._" : "^@\\s"
+    name_validation = options[:strict_mode] ? "-\\p{L}\\d+._'" : "^@\\s"
 
     /\A\s*([#{name_validation}]{1,64})@((?:[-\p{L}\d]+\.)+\p{L}{2,})\s*\z/i
   end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -49,7 +49,8 @@ describe EmailValidator do
         "nigel.worthington@big.co.uk",
         "f@c.com",
         "areallylongnameaasdfasdfasdfasdf@asdfasdfasdfasdfasdf.ab.cd.ef.gh.co.ca",
-        "ящик@яндекс.рф"
+        "ящик@яндекс.рф",
+        "evan.o'malley@gmail.com"
       ].each do |email|
 
         it "#{email.inspect} should be valid" do


### PR DESCRIPTION
This mainly handles Irish names like O'Malley and O'Toole which result in emails like `evan.o'malley@gmail.com` or `lizo'toole@yahoo.com`, both of which are valid.

Fixes #37 
