### PR TITLE
Adds invalid? method

### DIFF
--- a/lib/email_validator.rb
+++ b/lib/email_validator.rb
@@ -15,6 +15,10 @@ class EmailValidator < ActiveModel::EachValidator
     !!(value =~ regexp(options))
   end
 
+  def self.invalid?(value, options = {})
+    !valid?(value, options)
+  end
+
   def self.default_options
     @@default_options
   end

--- a/spec/email_validator_spec.rb
+++ b/spec/email_validator_spec.rb
@@ -56,6 +56,10 @@ describe EmailValidator do
           expect(TestUser.new(:email => email)).to be_valid
         end
 
+        it "#{email.inspect} should not be invalid" do
+          expect(TestUser.new(:email => email)).not_to be_invalid
+        end
+
         it "#{email.inspect} should be valid in strict_mode" do
           expect(StrictUser.new(:email => email)).to be_valid
         end
@@ -104,6 +108,10 @@ describe EmailValidator do
 
         it "#{email.inspect} should not be valid" do
           expect(TestUser.new(:email => email)).not_to be_valid
+        end
+
+        it "#{email.inspect} should be invalid" do
+          expect(TestUser.new(:email => email)).to be_invalid
         end
 
         it "#{email.inspect} should not be valid in strict_mode" do


### PR DESCRIPTION
This is very ruby-ish, but I prefer to write `raise InvalidEmail if EmailValidator.invalid?(email)` instead of `raise InvalidEmail unless EmailValidator.valid?(email)` or `raise InvalidEmail if !EmailValidator.valid?(email)`

Added tests. Let me know if this is the correct way to create a PR, and if you support this change. Thanks!